### PR TITLE
fix: node importer

### DIFF
--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -54,6 +54,7 @@ export function node(options?: { static?: string | boolean; importer?: string })
               throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
             }
           }
+
           return {
             id: resolved.id,
           };

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -39,19 +39,20 @@ export function node(options?: { static?: string | boolean; importer?: string })
             if (!resolved) {
               throw new Error(`Failed to resolve importer ${options.importer}`);
             }
-          }
-          resolved = await this.resolve("@universal-deploy/node/serve", importer);
-          if (!resolved) {
-            try {
-              // Use node resolution to find a sub dependency
-              const require = createRequire(import.meta.url);
-              const entry = require.resolve("@universal-deploy/node/serve");
-
-              return {
-                id: entry,
-              };
-            } catch {
-              throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
+          } else {
+            resolved = await this.resolve("@universal-deploy/node/serve", importer);
+            if (!resolved) {
+              try {
+                // Use node resolution to find a sub dependency
+                const require = createRequire(import.meta.url);
+                const entry = require.resolve("@universal-deploy/node/serve");
+  
+                return {
+                  id: entry,
+                };
+              } catch {
+                throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
+              }
             }
           }
 

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -36,6 +36,9 @@ export function node(options?: { static?: string | boolean; importer?: string })
           let resolved;
           if (options?.importer) {
             resolved = await this.resolve(options.importer, importer);
+            if (!resolved) {
+              throw new Error(`Failed to resolve importer ${options.importer}`);
+            }
           }
           if (!resolved) {
             try {

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -33,26 +33,30 @@ export function node(options?: { static?: string | boolean; importer?: string })
           id: re_udNode,
         },
         async handler(id, importer) {
+          let resolved
           if (options?.importer) {
-            const resolved = await this.resolve(options.importer, importer);
+            resolved = await this.resolve(options.importer, importer);
             if (!resolved) {
               throw new Error(`Failed to resolve importer ${options.importer}`);
             }
-            return {
-              id: resolved.id,
-            };
           }
-          try {
-            // Use node resolution to find a sub dependency
-            const require = createRequire(import.meta.url);
-            const entry = require.resolve("@universal-deploy/node/serve");
+          resolved = await this.resolve("@universal-deploy/node/serve", importer);
+          if (!resolved) {
+            try {
+              // Use node resolution to find a sub dependency
+              const require = createRequire(import.meta.url);
+              const entry = require.resolve("@universal-deploy/node/serve");
 
-            return {
-              id: entry,
-            };
-          } catch {
-            throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
+              return {
+                id: entry,
+              };
+            } catch {
+              throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
+            }
           }
+          return {
+            id: resolved.id,
+          };
         },
       },
 

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -33,9 +33,8 @@ export function node(options?: { static?: string | boolean; importer?: string })
           id: re_udNode,
         },
         async handler(id, importer) {
-          let resolved;
           if (options?.importer) {
-            resolved = await this.resolve(options.importer, importer);
+            const resolved = await this.resolve(options.importer, importer);
             if (!resolved) {
               throw new Error(`Failed to resolve importer ${options.importer}`);
             }

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -33,13 +33,10 @@ export function node(options?: { static?: string | boolean; importer?: string })
           id: re_udNode,
         },
         async handler(id, importer) {
-          let importerResolvedId: string | undefined;
+          let resolved: { id: string} | undefined;
           if (options?.importer) {
-            const importerResolved = await this.resolve(options.importer);
-            importerResolvedId = importerResolved?.id;
+            resolved = await this.resolve(options.importer, importer);
           }
-
-          const resolved = await this.resolve("@universal-deploy/node/serve", importerResolvedId ?? importer);
           if (!resolved) {
             try {
               // Use node resolution to find a sub dependency

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -33,7 +33,7 @@ export function node(options?: { static?: string | boolean; importer?: string })
           id: re_udNode,
         },
         async handler(id, importer) {
-          let resolved
+          let resolved;
           if (options?.importer) {
             resolved = await this.resolve(options.importer, importer);
             if (!resolved) {
@@ -46,7 +46,7 @@ export function node(options?: { static?: string | boolean; importer?: string })
                 // Use node resolution to find a sub dependency
                 const require = createRequire(import.meta.url);
                 const entry = require.resolve("@universal-deploy/node/serve");
-  
+
                 return {
                   id: entry,
                 };

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -39,24 +39,21 @@ export function node(options?: { static?: string | boolean; importer?: string })
             if (!resolved) {
               throw new Error(`Failed to resolve importer ${options.importer}`);
             }
+            return {
+              id: resolved.id,
+            };
           }
-          if (!resolved) {
-            try {
-              // Use node resolution to find a sub dependency
-              const require = createRequire(import.meta.url);
-              const entry = require.resolve("@universal-deploy/node/serve");
+          try {
+            // Use node resolution to find a sub dependency
+            const require = createRequire(import.meta.url);
+            const entry = require.resolve("@universal-deploy/node/serve");
 
-              return {
-                id: entry,
-              };
-            } catch {
-              throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
-            }
+            return {
+              id: entry,
+            };
+          } catch {
+            throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
           }
-
-          return {
-            id: resolved.id,
-          };
         },
       },
 

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -33,7 +33,7 @@ export function node(options?: { static?: string | boolean; importer?: string })
           id: re_udNode,
         },
         async handler(id, importer) {
-          let resolved: { id: string} | undefined;
+          let resolved;
           if (options?.importer) {
             resolved = await this.resolve(options.importer, importer);
           }


### PR DESCRIPTION
### Description
Fix module resolution for `options.importer` in `@universal-deploy/node` vite plugin.

### Motivation and Context
1. Previously, when the plugin tried to resolve `options.importer`, the `this.resolve()` call was missing the base `importer` argument in its plugin hook. When `options.importer` is a relative path or an alias, Rollup/Rolldown/Vite needs the context of the requesting module to resolve the ID properly.
2. The constant `resolved` always resolves as `@universal-deploy/node/serve` ignoring the `options.importer` usage.

### What has changed?
Added the origin `importer` as the second argument to `this.resolve()` to ensure paths are always resolved correctly relative to the module that imported it.
Refactor logic of `resolved` to correctly use and resolve `options.importer`.

### Related
#23

### Reproduction of this PR
[template-vike-solid-daisyui-hono/tree/minimal-server-vercel](https://github.com/templates-ecosystem/template-vike-solid-daisyui-hono/tree/minimal-server-vercel) (commit [b203347](https://github.com/templates-ecosystem/template-vike-solid-daisyui-hono/commit/b203347b804666034179a1ee8f45859af3fcbca1))