### PR TITLE
feat(adapter-node): add customServe option to override default server entry

### DIFF
--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -39,7 +39,7 @@ export function node(options?: { static?: string | boolean; importer?: string; c
             importerResolvedId = importerResolved?.id;
           }
 
-          let resolved: Awaited<ReturnType<typeof this.resolve>> | undefined;
+          let resolved: { id: string } | undefined;
           if (options?.customServe) {
             resolved = await this.resolve(options.customServe, importerResolvedId ?? importer);
             if (!resolved) {

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -21,7 +21,7 @@ function findClientOutDir(env: Environment) {
 }
 
 // Creates a server and listens for connections in Node/Deno/Bun
-export function node(options?: { static?: string | boolean; importer?: string }): Plugin[] {
+export function node(options?: { static?: string | boolean; importer?: string; customServe?: string }): Plugin[] {
   return [
     // Resolves virtual:ud:node-entry to its node runtime id
     {
@@ -39,18 +39,28 @@ export function node(options?: { static?: string | boolean; importer?: string })
             importerResolvedId = importerResolved?.id;
           }
 
-          const resolved = await this.resolve("@universal-deploy/node/serve", importerResolvedId ?? importer);
-          if (!resolved) {
-            try {
-              // Use node resolution to find a sub dependency
-              const require = createRequire(import.meta.url);
-              const entry = require.resolve("@universal-deploy/node/serve");
+          let resolved: Awaited<ReturnType<typeof this.resolve>> | undefined;
+          if (options?.customServe) {
+            resolved = await this.resolve(options.customServe, importerResolvedId ?? importer);
+            if (!resolved) {
+              throw new Error(
+                `Failed to resolve customServe option ${JSON.stringify(options.customServe)} from ${JSON.stringify(importerResolvedId ?? importer)}`,
+              );
+            }
+          } else {
+            resolved = await this.resolve("@universal-deploy/node/serve", importerResolvedId ?? importer);
+            if (!resolved) {
+              try {
+                // Use node resolution to find a sub dependency
+                const require = createRequire(import.meta.url);
+                const entry = require.resolve("@universal-deploy/node/serve");
 
-              return {
-                id: entry,
-              };
-            } catch {
-              throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
+                return {
+                  id: entry,
+                };
+              } catch {
+                throw new Error(`Cannot find server entry ${JSON.stringify(id)}`);
+              }
             }
           }
 

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -39,7 +39,7 @@ export function node(options?: { static?: string | boolean; importer?: string; c
             importerResolvedId = importerResolved?.id;
           }
 
-          let resolved: { id: string } | undefined;
+          let resolved: { id: string } | null = null;
           if (options?.customServe) {
             resolved = await this.resolve(options.customServe, importerResolvedId ?? importer);
             if (!resolved) {

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -43,3 +43,4 @@ The `universalDeploy()` plugin accepts the following options:
 - `node`: Same options as the `@universal-deploy/node` adapter:
     - `static`: (string | boolean) The directory containing static assets. Defaults to the client output directory.
     - `importer`: (string) The importer to use when resolving the server entry.
+    - `customServe`: (string) Relative or absolute path to override the default server entry


### PR DESCRIPTION
This PR introduces a new `customServe` option to the `@universal-deploy/adapter-node` Vite plugin.

By default, the plugin resolves the virtual server entry to `@universal-deploy/node/serve`. With this change, users can now specify a custom module to act as the server entry point. This is highly beneficial for developers who need to customize the underlying server behavior, such as attaching custom middlewares, altering the request/response handling, or overriding the default Node.js HTTP server setup before passing requests to the universal application logic.

### Changes Made
- Added `customServe?: string` to the plugin options interface.
- Updated the `ud:node:entry` plugin's `resolveId` hook to intercept the virtual entry resolution.
- If `options.customServe` is provided, it uses Vite's module resolution to find the custom server entry relative to the importer.
- Throws a descriptive error if the `customServe` module cannot be resolved, improving developer experience.
- Implemented minor formatting/typographic improvements to the `options` type signature.

### Use Case Example of `vite.config`
```ts
import { node } from '@universal-deploy/node/vite'

export default {
  plugins: [
    node({
      // Resolves to your custom server implementation instead of the default
      customServe: './src/custom-server.ts'
    })
  ]
}

// OR

import universalDeploy from '@universal-deploy/vite'

export default {
  plugins: [
    ...universalDeploy({
      node: {
        // Resolves to your custom server implementation instead of the default
        customServe: './src/custom-server.ts'
      }
    })
  ]
}
```

### Motivation
To provide flexibility for applications deploying to Node.js, Deno, or Bun environments that require an advanced/custom server configuration seamlessly integrated into the Universal Deploy build step.