### PR TITLE
fix(node): resolve static dir at runtime so built artifacts are portable

### DIFF
--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "dev": "tsdown --watch",
     "build": "tsdown",
+    "test": "vitest run",
     "test:types": "tsc --noEmit"
   },
   "dependencies": {
@@ -31,7 +32,8 @@
     "@types/node": "^22.19.15",
     "tsdown": "^0.21.1",
     "typescript": "^5.9.3",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "vitest": "^4.0.0"
   },
   "files": [
     "dist/"

--- a/packages/adapter-node/src/serve.ts
+++ b/packages/adapter-node/src/serve.ts
@@ -1,3 +1,5 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import userServerEntry from "virtual:ud:catch-all";
 import type { Fetchable } from "@universal-deploy/store";
 import { type FetchHandler, type ServerMiddleware, serve as serveSrvx } from "srvx";
@@ -12,21 +14,22 @@ function assertFetchable(mod: unknown, id: string): Fetchable {
 
 async function startServer() {
   assertFetchable(userServerEntry, "virtual:ud:catch-all");
-  let { static: staticDir } = userServerEntry as unknown as FetchHandler & {
+  let { static: staticHint } = userServerEntry as unknown as FetchHandler & {
     static?: boolean | string;
   };
 
   // @ts-expect-error replaced by node plugin
-  if (__UD_STATIC__) staticDir = __UD_STATIC__;
+  if (__UD_STATIC__) staticHint = __UD_STATIC__;
 
   if (!process.env.NODE_ENV) {
     // @ts-expect-error replaced by node plugin
     process.env.NODE_ENV = __UD_PROD__ ? "production" : "development";
   }
 
-  if (staticDir === undefined || staticDir === true) {
-    staticDir = "public";
-  }
+  // Resolve a string hint against this module's runtime location — keeps the
+  // built artifact portable across filesystems (Docker, deploy targets, …).
+  const staticDir =
+    typeof staticHint === "string" ? resolve(dirname(fileURLToPath(import.meta.url)), staticHint) : undefined;
 
   const server = serveSrvx({
     ...userServerEntry,

--- a/packages/adapter-node/src/vite.spec.ts
+++ b/packages/adapter-node/src/vite.spec.ts
@@ -1,0 +1,174 @@
+import { resolve } from "node:path";
+import type { Environment } from "vite";
+import { describe, expect, it } from "vitest";
+import { resolveStaticHint } from "./vite.js";
+
+/**
+ * Build the minimal `Environment`-shaped stub `resolveStaticHint` touches:
+ *   - `config.root`             — Vite project root
+ *   - `config.build.outDir`     — current (SSR) env's outDir
+ *   - `getTopLevelConfig().environments[*].consumer | build.outDir` — sibling envs
+ *
+ * `findClientOutDir` walks the environments and picks the one with
+ * `consumer === "client"`. We model that via two entries (server + optional client)
+ * so the test can also exercise the "no client environment" code path.
+ */
+function makeEnv(opts: { root: string; serverOutDir: string; clientOutDir?: string }): Environment {
+  const envs: Record<string, { consumer: string; build: { outDir: string } }> = {
+    ssr: { consumer: "server", build: { outDir: opts.serverOutDir } },
+  };
+  if (opts.clientOutDir !== undefined) {
+    envs.client = { consumer: "client", build: { outDir: opts.clientOutDir } };
+  }
+  return {
+    config: {
+      root: opts.root,
+      build: { outDir: opts.serverOutDir },
+    },
+    getTopLevelConfig: () => ({ environments: envs }),
+  } as unknown as Environment;
+}
+
+/** What `serve.ts` does at runtime: `resolve(getEntryDir(), <hint>)`. */
+function runtimeResolve(serverEntryDir: string, hint: string | false): string | undefined {
+  return hint === false ? undefined : resolve(serverEntryDir, hint);
+}
+
+describe("resolveStaticHint", () => {
+  // ── `static: false` short-circuits ──
+  describe("static: false", () => {
+    it("returns false when both envs exist", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server", clientOutDir: "/p/dist/client" });
+      expect(resolveStaticHint(env, false)).toBe(false);
+    });
+
+    it("returns false even without a client env (no auto-detect attempted)", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server" });
+      expect(resolveStaticHint(env, false)).toBe(false);
+    });
+  });
+
+  // ── auto-detect from the client env's outDir ──
+  describe("auto-detect (static omitted)", () => {
+    it("returns entry-relative path when client outDir is a sibling", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server", clientOutDir: "/p/dist/client" });
+      expect(resolveStaticHint(env, undefined)).toBe("../client");
+    });
+
+    it("returns '.' when client outDir equals server outDir", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist", clientOutDir: "/p/dist" });
+      expect(resolveStaticHint(env, undefined)).toBe(".");
+    });
+
+    it("traverses multiple levels when outDirs are deeply nested apart", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server/inner", clientOutDir: "/p/dist/client" });
+      expect(resolveStaticHint(env, undefined)).toBe("../../client");
+    });
+
+    it("traverses outside the build tree when client is a sibling of root", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server", clientOutDir: "/q/static" });
+      // `../../../q/static` is the entry-relative path.
+      expect(resolveStaticHint(env, undefined)).toBe("../../../q/static");
+    });
+
+    it("returns false when no client environment is present", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server" });
+      expect(resolveStaticHint(env, undefined)).toBe(false);
+    });
+
+    it("treats `static: true` the same as omitted", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server", clientOutDir: "/p/dist/client" });
+      expect(resolveStaticHint(env, true)).toBe(resolveStaticHint(env, undefined));
+    });
+  });
+
+  // ── user-provided string path ──
+  describe("user-provided string", () => {
+    it("resolves a relative path against the Vite root", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server" });
+      // "dist/client" resolves to "/p/dist/client", relative to server outDir → "../client".
+      expect(resolveStaticHint(env, "dist/client")).toBe("../client");
+    });
+
+    it("ignores the auto-detected client outDir when an explicit string is given", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server", clientOutDir: "/p/dist/client" });
+      expect(resolveStaticHint(env, "other/dir")).toBe("../../other/dir");
+    });
+
+    it("passes an absolute path through unchanged (user owns the path)", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server" });
+      expect(resolveStaticHint(env, "/var/www/static")).toBe("/var/www/static");
+    });
+
+    it("handles a `./prefixed` relative path the same as a bare relative path", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server" });
+      expect(resolveStaticHint(env, "./dist/client")).toBe("../client");
+    });
+
+    it("handles a relative path that walks above the root", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server" });
+      // "../shared/static" from /p → /shared/static → relative to /p/dist/server → "../../../shared/static"
+      expect(resolveStaticHint(env, "../shared/static")).toBe("../../../shared/static");
+    });
+  });
+
+  // ── output shape guarantees ──
+  describe("output shape", () => {
+    it("always uses forward slashes (portable across build/runtime OS)", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server", clientOutDir: "/p/dist/client" });
+      const out = resolveStaticHint(env, undefined);
+      if (typeof out === "string") expect(out).not.toContain("\\");
+    });
+
+    it("never returns an empty string (collapses same-dir case to '.')", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist", clientOutDir: "/p/dist" });
+      expect(resolveStaticHint(env, undefined)).not.toBe("");
+    });
+  });
+
+  // ── roundtrip: build hint then runtime-resolve, verify portability ──
+  describe("roundtrip with runtime resolution", () => {
+    it("standard layout: same dist on a different filesystem still resolves to the right client dir", () => {
+      const env = makeEnv({
+        root: "/build-host/app",
+        serverOutDir: "/build-host/app/dist/server",
+        clientOutDir: "/build-host/app/dist/client",
+      });
+      const hint = resolveStaticHint(env, undefined);
+      // Move the dist to a totally different absolute path (simulating Docker bind-mount).
+      const newServerEntryDir = "/runtime-host/repo/app/dist/server";
+      expect(runtimeResolve(newServerEntryDir, hint)).toBe("/runtime-host/repo/app/dist/client");
+    });
+
+    it("user-provided relative string survives a filesystem move", () => {
+      const env = makeEnv({ root: "/build-host/app", serverOutDir: "/build-host/app/dist/server" });
+      const hint = resolveStaticHint(env, "dist/client");
+      const newServerEntryDir = "/elsewhere/dist/server";
+      expect(runtimeResolve(newServerEntryDir, hint)).toBe("/elsewhere/dist/client");
+    });
+
+    it("absolute user path resolves to itself from ANY entry dir", () => {
+      const env = makeEnv({ root: "/build-host/app", serverOutDir: "/build-host/app/dist/server" });
+      const hint = resolveStaticHint(env, "/var/www/static");
+      expect(runtimeResolve("/build-host/app/dist/server", hint)).toBe("/var/www/static");
+      expect(runtimeResolve("/totally/different/place", hint)).toBe("/var/www/static");
+    });
+
+    it("false short-circuits the entire static middleware (undefined at runtime)", () => {
+      const env = makeEnv({ root: "/p", serverOutDir: "/p/dist/server" });
+      const hint = resolveStaticHint(env, false);
+      expect(runtimeResolve("/anywhere", hint)).toBeUndefined();
+    });
+
+    it("nested entry layout (e.g. /dist/nested/server) roundtrips correctly", () => {
+      const env = makeEnv({
+        root: "/build/app",
+        serverOutDir: "/build/app/dist/nested/server",
+        clientOutDir: "/build/app/dist/nested/client",
+      });
+      const hint = resolveStaticHint(env, undefined);
+      expect(hint).toBe("../client");
+      expect(runtimeResolve("/runtime/copy/dist/nested/server", hint)).toBe("/runtime/copy/dist/nested/client");
+    });
+  });
+});

--- a/packages/adapter-node/src/vite.ts
+++ b/packages/adapter-node/src/vite.ts
@@ -1,4 +1,5 @@
 import { builtinModules, createRequire } from "node:module";
+import { isAbsolute, relative, resolve } from "node:path";
 import MagicString from "magic-string";
 import {
   type BuildEnvironmentOptions,
@@ -6,6 +7,7 @@ import {
   defaultExternalConditions,
   defaultServerConditions,
   type Environment,
+  normalizePath,
   type Plugin,
 } from "vite";
 
@@ -18,6 +20,18 @@ const re_udNode = /^virtual:ud:node-entry$/;
 function findClientOutDir(env: Environment) {
   const envs = Object.values(env.getTopLevelConfig().environments);
   return envs.find((e) => e.consumer === "client")?.build.outDir;
+}
+
+/** Compute the value baked into `__UD_STATIC__`. Absolute paths pass through —
+ *  the user owns them. Otherwise we emit a path relative to the server entry so
+ *  the artifact is portable across filesystems. */
+export function resolveStaticHint(env: Environment, configured: string | boolean | undefined): string | false {
+  if (configured === false) return false;
+  if (typeof configured === "string" && isAbsolute(configured)) return normalizePath(configured);
+  const abs = typeof configured === "string" ? resolve(env.config.root, configured) : findClientOutDir(env);
+  if (abs === undefined) return false;
+  // POSIX-style embedded path so a Windows build runs on POSIX too.
+  return normalizePath(relative(env.config.build.outDir, abs)) || ".";
 }
 
 // Creates a server and listens for connections in Node/Deno/Bun
@@ -65,23 +79,9 @@ export function node(options?: { static?: string | boolean; importer?: string })
           code: [/__UD_STATIC__/, /__UD_PROD__/],
         },
         handler(code) {
-          const outDir = findClientOutDir(this.environment);
-
           const s = new MagicString(code);
-
-          s.replace(
-            /__UD_STATIC__/g,
-            JSON.stringify(
-              typeof options?.static === "string" || typeof options?.static === "boolean"
-                ? options.static
-                : typeof outDir === "string"
-                  ? outDir
-                  : true,
-            ),
-          );
-
+          s.replace(/__UD_STATIC__/g, JSON.stringify(resolveStaticHint(this.environment, options?.static)));
           s.replace(/__UD_PROD__/g, JSON.stringify(true));
-
           if (s.hasChanged()) {
             return {
               code: s.toString(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       vite:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@27.3.0)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/store:
     dependencies:
@@ -2142,6 +2145,9 @@ packages:
   '@speed-highlight/core@1.2.12':
     resolution: {integrity: sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@sveltejs/acorn-typescript@1.0.9':
     resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
     peerDependencies:
@@ -2624,6 +2630,9 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
@@ -2635,20 +2644,46 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@vue/compiler-core@3.5.32':
     resolution: {integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==}
@@ -2984,6 +3019,10 @@ packages:
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
@@ -3432,6 +3471,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -5322,6 +5364,10 @@ packages:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
@@ -5767,6 +5813,47 @@ packages:
       '@types/node':
         optional: true
       '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^22.19.15
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -7647,6 +7734,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.12': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
@@ -8305,6 +8394,15 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -8313,9 +8411,21 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@vitest/mocker@4.1.7(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -8323,9 +8433,21 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -8333,11 +8455,19 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
+  '@vitest/spy@4.1.7': {}
+
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vue/compiler-core@3.5.32':
     dependencies:
@@ -8697,6 +8827,8 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -9176,6 +9308,8 @@ snapshots:
   es-module-lexer@1.5.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -11238,6 +11372,8 @@ snapshots:
 
   tinyrainbow@2.0.0: {}
 
+  tinyrainbow@3.1.0: {}
+
   tinyspy@4.0.4: {}
 
   tldts-core@7.0.19: {}
@@ -11630,6 +11766,35 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@27.3.0)(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@22.19.15)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.15
+      jsdom: 27.3.0
+    transitivePeerDependencies:
+      - msw
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
fix(node): resolve static dir at runtime so built artifacts are portable

The Node adapter previously baked the build host's absolute outDir into the artifact via the __UD_STATIC__ macro, so running the same dist/... on a different filesystem (Docker bind-mounts, deploy targets with a different WORKDIR, etc.) caused serveStatic to find nothing and /assets/* requests fell through to the next middleware as 500s.

The macro now carries a path relative to the server entry, computed at build time from the Vite environments' outDirs. The runtime resolves it against dirname(import.meta.url) so the same artifact works on any filesystem. Absolute paths passed via node({ static: '/abs/path' }) pass through unchanged — the user owns the path.

Relative paths passed to node({ static }) are now anchored to the server entry script's directory at runtime (instead of process.cwd() as before). For every realistic deploy — Docker, systemd, pm2 with custom cwd — this is what you'd actually want: the static dir tracks where the artifact lives, not where the user happened to launch node from. Setups that relied on the old cwd-relative behavior need to either pass an absolute path or make the relative path entry-relative.

This restores the runtime resolution that @photonjs/runtime's sirv.js-based adapter had, which was lost in the sirv → srvx/static migration.
