### PR TITLE
feat(vite): add `target` plugin for custom server wrapper entrypoint

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./target": "./dist/target.js"
   },
   "scripts": {
     "dev": "tsdown --watch",

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -1,0 +1,50 @@
+import type { BuildEnvironmentOptions, Plugin } from "vite";
+
+export interface TargetPluginOptions {
+  /**
+   * The entry point to your custom server implementation.
+   * e.g. `'./server/entrypoint.ts'`
+   */
+  entry: string;
+}
+
+/**
+ * A generic target plugin that overrides the server entry with a custom wrapper.
+ */
+export function target(options: TargetPluginOptions): Plugin[] {
+  return [
+    {
+      name: "ud:target:emit",
+      apply: "build",
+      config: {
+        order: "post",
+        handler() {
+          const buildEnvOptions: BuildEnvironmentOptions = {};
+          if (this.meta.rolldownVersion) {
+            buildEnvOptions.rolldownOptions = {
+              input: {
+                index: options.entry,
+              },
+            };
+          } else {
+            buildEnvOptions.rollupOptions = {
+              input: {
+                index: options.entry,
+              },
+            };
+          }
+
+          return {
+            environments: {
+              ssr: {
+                build: {
+                  ...buildEnvOptions,
+                },
+              },
+            },
+          };
+        },
+      },
+    },
+  ];
+}

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -11,7 +11,7 @@ export interface TargetPluginOptions {
 /**
  * A generic target plugin that overrides the server entry with a custom wrapper.
  */
-export function target(options: TargetPluginOptions): Plugin[] {
+export default function target(options: TargetPluginOptions): Plugin[] {
   return [
     {
       name: "ud:target:emit",

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -20,7 +20,7 @@ export default function target(options: TargetPluginOptions): Plugin[] {
         order: "post",
         handler() {
           const buildEnvOptions: BuildEnvironmentOptions = {};
-          if (this.meta.rolldownVersion) {
+          if (this.meta?.rolldownVersion) {
             buildEnvOptions.rolldownOptions = {
               input: {
                 index: options.entry,

--- a/packages/vite/tsdown.config.ts
+++ b/packages/vite/tsdown.config.ts
@@ -16,6 +16,7 @@ export default defineConfig([
     platform: "node",
     entry: {
       index: "./src/index.ts",
+      target: "./src/plugins/target.ts",
     },
   },
 ]);


### PR DESCRIPTION
This PR introduces a new generic `@universal-deploy/vite/target` plugin. It provides a robust alternative to #27 that placing a `customServe` option directly inside the `@universal-deploy/adapter-node` plugin.

Since custom wrappers can target platforms entirely unrelated to Node and shouldn't be forced into importing `virtual:ud:catch-all`, placing them under a dedicated target plugin provides better separation of concerns and more flexibility.

### Changes Made
- `@universal-deploy/vite`: Created a new `target` plugin (`@universal-deploy/vite/target`) that accepts an entry option
- **Rollup Configuration**: The target plugin updates `rollupOptions.input.index` (or `rolldownOptions`) for the SSR build to resolve to the custom entry point specified
- **Subpath Export**: Exposed the new plugin cleanly as `./target` in `packages/vite/package.json` exports

### Example Usage
```ts
// vite.config.ts
import universalDeploy from '@universal-deploy/vite'
import target from '@universal-deploy/vite/target'
export default {
  plugins: [
    ...universalDeploy(),
    // Resolves to your custom server implementation instead of the default wrapper
    target({
      entry: './server/entrypoint.ts'
    })
  ]
}

// Vike (Draft)
// /pages/+config.ts
export default {
  serverEntry: './server/entrypoint.ts'
}

// vike/dist/node/vite/plugins/pluginUniversalDeploy.js
// https://github.com/vikejs/vike/blob/a8ac6c41b2d12e18b56118053e20b7cc19c25271/packages/vike/src/node/vite/plugins/pluginUniversalDeploy.ts
import universalDeploy from '@universal-deploy/vite'
import target from '@universal-deploy/vite/target'
// ...
function pluginUniversalDeploy(vikeConfig: VikeConfigInternal): Plugin[] {
  // ...
  return [
    ...universalDeploy(),
    // Resolves to your custom server implementation from +config.serverEntry instead of the default wrapper
    ...vikeConfig.config.serverEntry
      ? [target({ entry: vikeConfig.config.serverEntry })]
      : []
  ]
}
```

### Motivation
This resolves the feature request for a custom server wrapper in Universal Deploy builds seamlessly, maintaining clean architecture by keeping the custom target decoupled from platform-specific adapters like `@universal-deploy/adapter-node`.

### Additional info
- Tested on [templates-ecosystem/template-vike-solid-daisyui-hono/tree/minimal-server-vercel](https://github.com/templates-ecosystem/template-vike-solid-daisyui-hono/tree/minimal-server-vercel) commit [541f312](https://github.com/templates-ecosystem/template-vike-solid-daisyui-hono/commit/541f3121654f34890de13150beee5e6cef19b84b)
- Alternative #31