### PR TITLE
feat(vite): add `entry` option

### DIFF
--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -43,3 +43,4 @@ The `universalDeploy()` plugin accepts the following options:
 - `node`: Same options as the `@universal-deploy/node` adapter:
     - `static`: (string | boolean) The directory containing static assets. Defaults to the client output directory.
     - `importer`: (string) The importer to use when resolving the server entry.
+- `entry`: (string) Relative or absolute path to override the default server entry.

--- a/packages/vite/src/plugins/auto.ts
+++ b/packages/vite/src/plugins/auto.ts
@@ -5,13 +5,14 @@ import { catchAll, devServer } from "../index.js";
 import { enablePluginIf } from "../utils.js";
 import { netlifyGlue } from "./glue.js";
 import { noDeploymentTargetFound } from "./supported.js";
+import target from "./target.js";
 
 type NodePluginOptions = Parameters<typeof node>[0];
 
 /**
  * Automatically enables the node adapter if no other deployment target (Vercel, Cloudflare, Netlify) is detected.
  */
-export function auto(options?: { node?: NodePluginOptions }): Plugin[] {
+export function auto(options?: { node?: NodePluginOptions; entry?: string }): Plugin[] {
   const instance = Symbol("instance");
   return [
     catchAll(),
@@ -23,6 +24,7 @@ export function auto(options?: { node?: NodePluginOptions }): Plugin[] {
       // Disable node() plugin later when Vite's config() hook runs, because noDeploymentTargetFound() requires `config`
       return enablePluginIf((config) => noDeploymentTargetFound(p, config), p);
     }),
+    ...options?.entry ? [target(options.entry)] : [],
     ...netlifyGlue(),
   ];
 }

--- a/packages/vite/src/plugins/auto.ts
+++ b/packages/vite/src/plugins/auto.ts
@@ -17,13 +17,17 @@ export function auto(options?: { node?: NodePluginOptions; entry?: string }): Pl
   return [
     catchAll(),
     devServer(),
-    // Enable node adapter only if no other deployment target has been found
-    ...node(options?.node).map((p) => {
-      // @ts-expect-error
-      p[INSTANCE] = instance;
-      // Disable node() plugin later when Vite's config() hook runs, because noDeploymentTargetFound() requires `config`
-      return enablePluginIf((config) => noDeploymentTargetFound(p, config), p);
-    }),
-    ...(options?.entry ? [target(options.entry)] : netlifyGlue()),
+    ...(options?.entry
+      ? [target(options.entry)]
+      : [
+        // Enable node adapter only if no other deployment target has been found
+        ...node(options?.node).map((p) => {
+          // @ts-expect-error
+          p[INSTANCE] = instance;
+          // Disable node() plugin later when Vite's config() hook runs, because noDeploymentTargetFound() requires `config`
+          return enablePluginIf((config) => noDeploymentTargetFound(p, config), p);
+        }),
+        ...netlifyGlue(),
+      ]),
   ];
 }

--- a/packages/vite/src/plugins/auto.ts
+++ b/packages/vite/src/plugins/auto.ts
@@ -24,7 +24,7 @@ export function auto(options?: { node?: NodePluginOptions; entry?: string }): Pl
       // Disable node() plugin later when Vite's config() hook runs, because noDeploymentTargetFound() requires `config`
       return enablePluginIf((config) => noDeploymentTargetFound(p, config), p);
     }),
-    ...options?.entry ? [target(options.entry)] : [],
+    ...(options?.entry ? [target(options.entry)] : []),
     ...netlifyGlue(),
   ];
 }

--- a/packages/vite/src/plugins/auto.ts
+++ b/packages/vite/src/plugins/auto.ts
@@ -20,14 +20,14 @@ export function auto(options?: { node?: NodePluginOptions; entry?: string }): Pl
     ...(options?.entry
       ? [target(options.entry)]
       : [
-        // Enable node adapter only if no other deployment target has been found
-        ...node(options?.node).map((p) => {
-          // @ts-expect-error
-          p[INSTANCE] = instance;
-          // Disable node() plugin later when Vite's config() hook runs, because noDeploymentTargetFound() requires `config`
-          return enablePluginIf((config) => noDeploymentTargetFound(p, config), p);
-        }),
-        ...netlifyGlue(),
-      ]),
+          // Enable node adapter only if no other deployment target has been found
+          ...node(options?.node).map((p) => {
+            // @ts-expect-error
+            p[INSTANCE] = instance;
+            // Disable node() plugin later when Vite's config() hook runs, because noDeploymentTargetFound() requires `config`
+            return enablePluginIf((config) => noDeploymentTargetFound(p, config), p);
+          }),
+          ...netlifyGlue(),
+        ]),
   ];
 }

--- a/packages/vite/src/plugins/auto.ts
+++ b/packages/vite/src/plugins/auto.ts
@@ -24,7 +24,6 @@ export function auto(options?: { node?: NodePluginOptions; entry?: string }): Pl
       // Disable node() plugin later when Vite's config() hook runs, because noDeploymentTargetFound() requires `config`
       return enablePluginIf((config) => noDeploymentTargetFound(p, config), p);
     }),
-    ...(options?.entry ? [target(options.entry)] : []),
-    ...netlifyGlue(),
+    ...(options?.entry ? [target(options.entry)] : netlifyGlue()),
   ];
 }

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -46,9 +46,7 @@ export default function target(entry: string): Plugin {
     transform(code, id) {
       if (resolvedEntry && id === resolvedEntry) {
         if (!code.includes("virtual:ud:")) {
-          this.warn(
-            `The defined UD wrapper "${entry}" does not seem to import any "virtual:ud:" entries.`
-          );
+          this.warn(`The defined UD wrapper "${entry}" does not seem to import any "virtual:ud:" entries.`);
         }
       }
     },

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -4,6 +4,7 @@ import type { BuildEnvironmentOptions, Plugin } from "vite";
  * A generic target plugin that overrides the server entry with a custom wrapper.
  */
 export default function target(entry: string): Plugin {
+  let resolvedEntry: string | undefined;
   return {
     name: "ud:target:emit",
     apply: "build",
@@ -35,6 +36,21 @@ export default function target(entry: string): Plugin {
           },
         };
       },
+    },
+    async buildStart() {
+      const resolved = await this.resolve(entry);
+      if (resolved) {
+        resolvedEntry = resolved.id;
+      }
+    },
+    transform(code, id) {
+      if (resolvedEntry && id === resolvedEntry) {
+        if (!code.includes("virtual:ud:")) {
+          this.warn(
+            `The defined UD wrapper "${entry}" does not seem to import any "virtual:ud:" entries.`
+          );
+        }
+      }
     },
   };
 }

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -46,7 +46,7 @@ export default function target(entry: string): Plugin {
     transform(code, id) {
       if (resolvedEntry && id === resolvedEntry) {
         if (!code.includes("virtual:ud:")) {
-          this.warn(`{ entry: "${entry}" } is missing "virtual:ud:catch-all" entry.`);
+          this.warn(`{ entry: "${entry}" } is missing "virtual:ud:catch-all" import.`);
         }
       }
     },

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -1,0 +1,40 @@
+import type { BuildEnvironmentOptions, Plugin } from "vite";
+
+/**
+ * A generic target plugin that overrides the server entry with a custom wrapper.
+ */
+export default function target(entry: string): Plugin {
+  return {
+    name: "ud:target:emit",
+    apply: "build",
+    config: {
+      order: "post",
+      handler() {
+        const buildEnvOptions: BuildEnvironmentOptions = {};
+        if (this.meta.rolldownVersion) {
+          buildEnvOptions.rolldownOptions = {
+            input: {
+              index: entry,
+            },
+          };
+        } else {
+          buildEnvOptions.rollupOptions = {
+            input: {
+              index: entry,
+            },
+          };
+        }
+
+        return {
+          environments: {
+            ssr: {
+              build: {
+                ...buildEnvOptions,
+              },
+            },
+          },
+        };
+      },
+    },
+  };
+}

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -11,7 +11,7 @@ export default function target(entry: string): Plugin {
       order: "post",
       handler() {
         const buildEnvOptions: BuildEnvironmentOptions = {};
-        if (this.meta.rolldownVersion) {
+        if (this.meta?.rolldownVersion) {
           buildEnvOptions.rolldownOptions = {
             input: {
               index: entry,

--- a/packages/vite/src/plugins/target.ts
+++ b/packages/vite/src/plugins/target.ts
@@ -46,7 +46,7 @@ export default function target(entry: string): Plugin {
     transform(code, id) {
       if (resolvedEntry && id === resolvedEntry) {
         if (!code.includes("virtual:ud:")) {
-          this.warn(`The defined UD wrapper "${entry}" does not seem to import any "virtual:ud:" entries.`);
+          this.warn(`{ entry: "${entry}" } is missing "virtual:ud:catch-all" entry.`);
         }
       }
     },


### PR DESCRIPTION
Add `entry` option as `@universal-deploy/vite` option.

### Example Usage
```ts
// vite.config.ts
import universalDeploy from '@universal-deploy/vite'
export default {
  plugins: [
    // Resolves to your custom server implementation instead of the default wrapper
    ...universalDeploy({ entry: './server/entrypoint.ts' })
  ]
}

// Vike (Draft)
// /pages/+config.ts
export default {
  serverEntry: './server/entrypoint.ts'
}

// vike/dist/node/vite/plugins/pluginUniversalDeploy.js
// https://github.com/vikejs/vike/blob/a8ac6c41b2d12e18b56118053e20b7cc19c25271/packages/vike/src/node/vite/plugins/pluginUniversalDeploy.ts
import universalDeploy from '@universal-deploy/vite'
// ...
function pluginUniversalDeploy(vikeConfig: VikeConfigInternal): Plugin[] {
  // ...
  return [
    // Resolves to your custom server implementation from +config.serverEntry instead of the default wrapper
    ...universalDeploy({ entry: vikeConfig.config.serverEntry }),
    // ...
  ]
}
```

### Additional info
- Alternative to #30